### PR TITLE
fix: register jadx input plugins in shadow jar (APK only resolves 1 class)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,4 +76,12 @@ tasks.register<JavaExec>("bench") {
 tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
     archiveClassifier.set("all")
     mergeServiceFiles()
+    // ShadowJar defaults to DuplicatesStrategy.EXCLUDE, which silently drops the duplicate
+    // META-INF/services/jadx.api.plugins.JadxPlugin files from jadx-dex-input, jadx-java-input,
+    // jadx-java-convert, jadx-smali-input, jadx-raung-input and jadx-xapk-input BEFORE
+    // mergeServiceFiles() can merge them. The released fat jar then registers only
+    // KotlinMetadataPlugin, so no dex/java/smali input plugin is loaded at runtime: every APK
+    // resolves to just the resources-derived R class (1 class) and bare dex files to 0 classes.
+    // INCLUDE routes every copy into the ServiceFileTransformer, which concatenates the entries.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }


### PR DESCRIPTION
## Problem

The released v0.3.0 fat jar (and any locally-built jar from this repo) resolves **every APK to exactly 1 class** — the resources-derived `R` class — and bare `.dex` files to **0 classes**. This breaks all jadx-mcp static analysis for real-world (R8-obfuscated) APKs.

## Root cause

jadx 1.5.x registers its input plugins (dex / java / smali / raung / xapk / javaconvert) through `META-INF/services/jadx.api.plugins.JadxPlugin`. Each input module ships the same service path, and the fat jar must merge those entries.

Shadow's `ShadowJar` task **defaults to `DuplicatesStrategy.EXCLUDE`** (see `ShadowJar.kt`). With EXCLUDE, duplicate resource paths are silently dropped *before* transformers run, so `mergeServiceFiles()` never sees them. The resulting jar's service file contained only:

```
jadx.plugins.kotlin.metadata.KotlinMetadataPlugin
```

Missing: `jadx.plugins.input.dex.DexInputPlugin`, `jadx.plugins.input.java.JavaInputPlugin`, `jadx.plugins.input.smali.SmaliInputPlugin`, `jadx.plugins.input.raung.RaungInputPlugin`, `jadx.plugins.input.xapk.XApkInputPlugin`, `jadx.plugins.input.javaconvert.JavaConvertPlugin`.

Runtime evidence (SLF4J debug on the released jar):

```
[main] DEBUG jadx.core.plugins.JadxPluginManager - Loading plugin: kotlin-metadata
[main] DEBUG jadx.api.JadxDecompiler - Resolved plugins: [kotlin-metadata]
[main] DEBUG jadx.api.JadxDecompiler - Loaded using 0 inputs plugin in 0 ms
[main] INFO  jadx.core.dex.nodes.RootNode - Loaded classes: 0, methods: 0, instructions: 0
```

No input plugin → the dex is never parsed → only resources are processed (1 synthetic `R` class; 0 classes for a standalone dex).

## Fix

```kotlin
tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
    archiveClassifier.set("all")
    mergeServiceFiles()
    duplicatesStrategy = DuplicatesStrategy.INCLUDE
}
```

`INCLUDE` routes every duplicate service file into the `ServiceFileTransformer`, which concatenates the plugin entries into a single registered list.

## Verification (against an R8-obfuscated 7.6 MB single-dex APK)

| | released jar (broken) | rebuilt jar (fixed) |
|---|---|---|
| `META-INF/services/jadx.api.plugins.JadxPlugin` | 1 entry | **7 entries** |
| `decompiler.classes` (APK) | 1 (`...R`) | **6844** |
| bare `classes.dex` load | 0 | **6860** |
| jadx `Loaded classes` (dex) | 0 | 7792 |

Same probe code: broken jar logs `Loaded using 0 inputs plugin in 0 ms`; fixed jar logs `Resolved plugins: [kotlin-metadata, javaconvert, smali, xapk, dex, java, raung]` and loads all classes. No behavioural change beyond plugin registration — this only restores the input plugins that were silently stripped from the release artifact.